### PR TITLE
Working jupyter notebook online with NuShell kernel

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,2 @@
+libxcb-shape0
+libxcb-xfixes0

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+channels:
+- conda-forge
+dependencies:
+# Jupyter
+- jupyterlab=2
+- nodejs=11
+- nbconvert=5.5
+- widgetsnbextension=3.5
+# Python Kernel
+- ipykernel=5.1
+- ipywidgets=7.5
+- ipyleaflet=0.12
+- altair=3.1
+- bqplot=0.12
+- dask=2.1
+- matplotlib=3.1
+- pandas=0.24
+- python=3.7
+- scikit-image=0.15
+- scikit-learn=0.21
+- seaborn=0.9
+- tensorflow=1.13
+- sympy=1.4
+- pyyaml
+- traittypes==0.2.1
+- invoke=1.2

--- a/postBuild
+++ b/postBuild
@@ -18,6 +18,7 @@ set -ex
 curl https://sh.rustup.rs -sSf > ~/rustup-init.sh
 chmod +x ~/rustup-init.sh
 ~/rustup-init.sh -y
+source $HOME/.cargo/env
 # Rustup
 rustc --version
 # Install NuShell with Cargo

--- a/postBuild
+++ b/postBuild
@@ -25,6 +25,9 @@ rustc --version
 #cargo install nu --features=stable
 #cargo install nu --features=average,fetch,inc,match,post,ps,start,str,sys,textview,tree
 cargo install nu
+# Pull tree
+git clone https://github.com/fdncred/nu_jupyter.git
+cd nu_jupyter
 # Install NuShell kernelspec
-python setup.py bdist_egg
-jupyter kernelspec install --user
+#python setup.py bdist_egg
+jupyter kernelspec install ../nu_jupyter --user

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,11 @@
 #!/bin/bash
 set -ex
+# Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+# Following Brew's instructions
+echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
+eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
+# Use Brew to install NuShell
 brew install nushell
+# Install NuShell kernelspec
+jupyter kernelspec install ../nu_jupyter --user

--- a/postBuild
+++ b/postBuild
@@ -6,6 +6,12 @@ set -ex
 echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
 eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
 brew tap linuxbrew/xorg
+brew install gcc
+# Let's install rust
+brew install rust
+# Rustup
+rustup-init
+rustc --version
 # Use Brew to install NuShell
 brew install nushell
 # Install NuShell kernelspec

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+brew install nushell

--- a/postBuild
+++ b/postBuild
@@ -14,7 +14,10 @@ set -ex
 # Use Brew to install NuShell
 #brew install nushell
 
-curl https://sh.rustup.rs -sSf | sh -- -y
+#curl https://sh.rustup.rs -sSf | sh -- -y
+curl https://sh.rustup.rs -sSf > ~/rustup-init.sh
+chmod +x ~/rustup-init.sh
+~/rustup-init.sh -y
 # Rustup
 rustc --version
 # Install NuShell with Cargo

--- a/postBuild
+++ b/postBuild
@@ -27,4 +27,4 @@ rustc --version
 cargo install nu
 # Install NuShell kernelspec
 python setup.py bdist_egg
-jupyter kernelspec install . --user
+jupyter kernelspec install --user

--- a/postBuild
+++ b/postBuild
@@ -27,5 +27,4 @@ rustc --version
 cargo install nu
 # Install NuShell kernelspec
 python setup.py bdist_egg
-#jupyter kernelspec install . --user
-jupyter kernelspec install .
+jupyter kernelspec install . --user

--- a/postBuild
+++ b/postBuild
@@ -26,4 +26,5 @@ rustc --version
 #cargo install nu --features=average,fetch,inc,match,post,ps,start,str,sys,textview,tree
 cargo install nu
 # Install NuShell kernelspec
-jupyter kernelspec install ../nu_jupyter --user
+python setup.py bdist_egg
+jupyter kernelspec install . --user

--- a/postBuild
+++ b/postBuild
@@ -14,7 +14,7 @@ set -ex
 # Use Brew to install NuShell
 #brew install nushell
 
-curl https://sh.rustup.rs -sSf | sh
+curl https://sh.rustup.rs -sSf | sh -- -y
 # Rustup
 rustc --version
 # Install NuShell with Cargo

--- a/postBuild
+++ b/postBuild
@@ -8,7 +8,7 @@ eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
 brew tap linuxbrew/xorg
 brew install gcc
 # Let's install rust
-brew install rust
+brew install rustup
 # Rustup
 rustup-init
 rustc --version

--- a/postBuild
+++ b/postBuild
@@ -27,4 +27,5 @@ rustc --version
 cargo install nu
 # Install NuShell kernelspec
 python setup.py bdist_egg
-jupyter kernelspec install . --user
+#jupyter kernelspec install . --user
+jupyter kernelspec install .

--- a/postBuild
+++ b/postBuild
@@ -5,6 +5,7 @@ set -ex
 # Following Brew's instructions
 echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
 eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
+brew tap linuxbrew/xorg
 # Use Brew to install NuShell
 brew install nushell
 # Install NuShell kernelspec

--- a/postBuild
+++ b/postBuild
@@ -2,12 +2,12 @@
 set -ex
 
 # Install Homebrew
-#/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 # Following Brew's instructions
-#echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
-#eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
-#brew tap linuxbrew/xorg
-#brew install gcc
+echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
+eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
+brew tap linuxbrew/xorg
+brew install gcc
 # Let's install rust
 #brew install rustup
 #rustup-init

--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -ex
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew install nushell

--- a/postBuild
+++ b/postBuild
@@ -1,18 +1,23 @@
 #!/bin/bash
 set -ex
+
 # Install Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+#/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 # Following Brew's instructions
-echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
-eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
-brew tap linuxbrew/xorg
-brew install gcc
+#echo 'eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)' >> /home/jovyan/.profile
+#eval $(/home/jovyan/.linuxbrew/bin/brew shellenv)
+#brew tap linuxbrew/xorg
+#brew install gcc
 # Let's install rust
-brew install rustup
-# Rustup
-rustup-init
-rustc --version
+#brew install rustup
+#rustup-init
 # Use Brew to install NuShell
-brew install nushell
+#brew install nushell
+
+curl https://sh.rustup.rs -sSf | sh
+# Rustup
+rustc --version
+# Install NuShell with Cargo
+cargo install nu --features=stable
 # Install NuShell kernelspec
 jupyter kernelspec install ../nu_jupyter --user

--- a/postBuild
+++ b/postBuild
@@ -22,6 +22,8 @@ source $HOME/.cargo/env
 # Rustup
 rustc --version
 # Install NuShell with Cargo
-cargo install nu --features=stable
+#cargo install nu --features=stable
+#cargo install nu --features=average,fetch,inc,match,post,ps,start,str,sys,textview,tree
+cargo install nu
 # Install NuShell kernelspec
 jupyter kernelspec install ../nu_jupyter --user


### PR DESCRIPTION
Right now the binder in discord points to my fork, but anyone can create a fork and run it or run it off the nushell master.

This is my current [url](https://mybinder.org/v2/gh/fdncred/nu_jupyter/60d0006f8e808e2a187415c62ec1582c2b478e13).


if you go to mybinder.org and put the regular nushell/nu_jupyter url in the github link it'll create a new one. Then one can copy the `Copy Binder Link` and publish it for anyone to use.

TBD - install nu with --features=stable